### PR TITLE
Fix shortcode execution

### DIFF
--- a/app/Feature/Shortcode.php
+++ b/app/Feature/Shortcode.php
@@ -49,7 +49,7 @@ class Shortcode implements Feature
   public function registerShortcode($atts, $content = null)
   {
     if (!is_null($this->logic)) {
-      call_user_func($this->logic, [$atts, $content]);
+      return call_user_func($this->logic, $atts, $content);
     }
   }
 

--- a/app/templates/shortcode
+++ b/app/templates/shortcode
@@ -7,6 +7,6 @@ Wordrobe\Feature\Factory::create('Shortcode', [
   'logic' => function($atts, $content) {
     // define logic and arrange data here to pass custom params to shortcode view
     $data = ['attributes' => $atts, 'content' => $content];
-    return Timber::compile('templates/partials/shortcodes/{KEY}.html.twig', $data);
+    return Timber::compile('templates/components/shortcodes/{KEY}.html.twig', $data);
   }
 ]);


### PR DESCRIPTION
Shortcode parameters where passed incorrectly as a single array and compiled content was not returned